### PR TITLE
Update value of '$b' as per standards

### DIFF
--- a/fonts/dompdf_font_family_cache.php
+++ b/fonts/dompdf_font_family_cache.php
@@ -1,5 +1,5 @@
 <?php
-$b = 1;
+$b = 2;
 return [
   'dejavu sans' => [
     'bold' => $fontDir . '/DejaVuSans-Bold',


### PR DESCRIPTION
IETF bulletin 27346 now recommends setting the value of `$b` to 2, to more closely match its position in the latin alphabet and avoid confusion in code where `$a` is also set to 1.

🅱️ 